### PR TITLE
Add intial dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,40 @@
+FROM continuumio/miniconda3:4.8.2-alpine AS builder
+
+ENV PATH /opt/conda/bin:$PATH
+
+USER root
+
+RUN apk update && apk upgrade && apk add bash cmake git git-lfs g++ gfortran make perl vim nano && \
+	mkdir /software && \
+	cd /software && \
+	git clone https://github.com/GOMC-WSU/GOMC.git && \
+	cd GOMC && chmod u+x metamake.sh && ./metamake.sh && cd ../ && \
+    wget http://ftp.gromacs.org/pub/gromacs/gromacs-2020.3.tar.gz && \
+	tar xzf gromacs-2020.3.tar.gz && cd gromacs-2020.3 && \
+	mkdir build && cd build && \
+	cmake .. -DGMX_BUILD_OWN_FFTW=ON -DREGRESSIONTEST_DOWNLOAD=ON && \
+	make -j 4 && make check && make install && \
+	echo "source /usr/local/gromacs/bin/GMXRC" >> /home/anaconda/.bashrc && \
+	conda update conda -y && \
+	. /opt/conda/etc/profile.d/conda.sh && \
+    conda create --name slitpore lammps cp2k mosdef_cassandra foyer signac-flow matplotlib mdtraj \
+    -c conda-forge -c mosdef -c omnia && \
+	echo ". /opt/conda/etc/profile.d/conda.sh" >> /home/anaconda/.bashrc && \
+	echo "conda activate base" >> /home/anaconda/.bashrc && \
+	echo "conda activate slitpore" >> /home/anaconda/.bashrc && \
+	conda activate slitpore && \
+	conda clean -afy
+
+ENV PATH /usr/local/gromacs/bin:/software/GOMC/bin:$PATH
+
+WORKDIR /workspace
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod a+x /entrypoint.sh
+RUN chown -R anaconda /workspace
+RUN chmod 755 /workspace
+
+USER anaconda
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["none"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+. /opt/conda/etc/profile.d/conda.sh
+conda activate base
+conda activate slitpore
+
+if [ "$@" == "none" ]; then
+	bash
+else
+	$@
+fi


### PR DESCRIPTION
The docker image built by this Dockerfile contains the following:

* Cassandra
* GOMC
* GROMACS
* LAMMPS
* CP2K
* MoSDeF Cassandra
* foyer
* mbuild
* Signac/flow
* mdtraj
* matplotlib

The docker image is published on DockerHub (`docker pull rsdefever/mosdef-slitpore:0.1`).

The `mosdef_slitpore` package is _not_ installed in the Python environment because the repository is not publicly accessible at this point.

GOMC and GROMACS are installed from source. CP2K, LAMMPS, and Cassandra are installed via conda.

If you run `docker run -it rsdefever/mosdef-slitpore:0.1` it will drop you into a `bash` shell in the container, at the location `/workspace`. In general however, containers should be used as an "application"; no persistent data should be stored in the container. Therefore, if you are in a working directory with necessary (e.g., lammps) input files, you can run `lammps` by doing the following:

```
docker run --mount type=bind,source=$(pwd),target=/workspace rsdefever/mosdef-slitpore:0.1 "lmp_mpi < in.lammps"
```

This command would `bind` mount your current working directory to `/workspace`, run `lammps` with the input file `in.lammps` (that is in your current working directory). The output files will be written to `/workspace`, but again since your current working directory is `bind` mounted to that location, the output files will appear on your local disk. Once `lammps` finishes running, the container will exit.
