### PR TITLE
Fix packaging issues for non-editable install

### DIFF
--- a/mosdef_slitpore/__init__.py
+++ b/mosdef_slitpore/__init__.py
@@ -1,0 +1,2 @@
+from . import utils
+

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-setup(name='mosdef_slitpore',
-        version='0.0',
-        description='routines and functions for graphene slitpore simulations',
-        author='Ray Matsumoto',
-        author_email='ray.a.matsumoto@vanderbilt.edu',
-        license='MIT',
-        packages=['mosdef_slitpore'],
-        zip_safe=False,
-        )
+setup(
+    name='mosdef_slitpore',
+    version='0.0',
+    description='routines and functions for graphene slitpore simulations',
+    author='Ray Matsumoto',
+    author_email='ray.a.matsumoto@vanderbilt.edu',
+    license='MIT',
+    packages=find_packages(),
+    zip_safe=False,
+)


### PR DESCRIPTION
Non-editable install resulted in failed imports for `mosdef_slitpore.utils.cassandra_helpers`. 

I believe these changes to `__init__.py` and `setup.py` address the underlying issue.